### PR TITLE
Added INFO code 56 to codes dictionary

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,6 +19,7 @@ const codes = Dict(
     44  => "Terminated after numerical difficulties: ill-conditioned null-space basis",
     51  => "Error in the user-supplied functions: incorrect objective derivatives",
     52  => "Error in the user-supplied functions: incorrect constraint derivatives",
+    56  => "Error in the user-supplied functions: irregular or badly scaled problem functions",
     61  => "Undefined user-supplied functions: undefined function at the first feasible point",
     62  => "Undefined user-supplied functions: undefined function at the initial point",
     63  => "Undefined user-supplied functions: unable to proceed into undefined region",


### PR DESCRIPTION
Previously, info code 56 was not included within the `codes` `Dict` in src/utils.jl. This would result in an error on the rare chance INFO code 56 was returned from `snopta`.